### PR TITLE
0.3.2-beta3

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin url="https://github.com/phalcon/zephir-idea-plugin">
   <id>com.zephir</id>
   <name>Zephir</name>
-  <version>0.3.2-beta1</version>
+  <version>0.3.2-beta3</version>
   <vendor email="support@phalconphp.com" url="https://zephir-lang.com">Zephir Team</vendor>
 
   <description><![CDATA[
@@ -12,6 +12,7 @@
     ]]></description>
 
   <change-notes><![CDATA[
+        <li><b>0.3.2-beta3</b> Fixed regex recognition bug. Added syntax support for constructions like {var} </li>
         <li><b>0.3.2-beta2</b>: Improved syntax support. Fixed completion bug when invoking AC in method definition block</li>
         <li><b>0.3.2-beta1</b>: Introduced class members in completion list</li>
         <li><b>0.3.1</b>: Fixed much bugs with syntax recognition, fixed extra space in completion for method params</li>

--- a/src/com/zephir/Zephir.bnf
+++ b/src/com/zephir/Zephir.bnf
@@ -22,7 +22,6 @@
         double='regexp:([\-]?[0-9]+[\.][0-9]+)'
         schar="regexp:(['] ([\\][']|[\\].|[\001-\377]\[\\'])* ['])"
         string='regexp:(["] ([\\]["]|[\\].|[\001-\377]\[\\"])* ["])'
-        //        string='regexp:"([\\][\"]|[\\].|[\001-\377])*"'
         cblock='regexp:%{([^}]+|[}]+[^%{])*}%'
 
         // OOP keywords
@@ -244,7 +243,7 @@ private declaration_statement_element ::= (id | php_reserved) default_value?
 let_statement ::= 'let' change_variable_expr (',' change_variable_expr)* ';' {pin(".*")=1}
 
 change_variable_expr ::= assignment_expr | increment_expr
-assignment_expr ::= (typecast | type)? (variable | php_reserved) array_append_expr? assignment_operator (typecast | type)?  (php_reserved | expr) { rightAssociative=true }
+assignment_expr ::= (typecast | type)? (variable | exploded_varable | php_reserved) array_append_expr? assignment_operator (typecast | type)?  (php_reserved | expr) { rightAssociative=true }
 
 private array_append_expr ::= '[' ']'
 assignment_operator ::= '=' | '+=' | '-=' | '*=' | '**=' | '/=' | '%=' | '.='
@@ -344,6 +343,7 @@ array_item ::= array_key_value | expr
 array_key_value ::= (scalar_short | expr) ':' expr
 
 variable ::= complex_id (property_access | array_append_expr |  array_access)*
+exploded_varable ::= '{' variable '}'
 
 private property_access ::= ('::' | '->') (variable | '{' (string | id) '}' | magic_call_expr) {pin=2}
 private array_access ::= '[' (expr | php_reserved) ']' {pin=1}

--- a/src/com/zephir/lexer/Zephir.flex
+++ b/src/com/zephir/lexer/Zephir.flex
@@ -32,7 +32,7 @@ DOUBLE_QUOTE = \x22
 SINGLE_QUOTE = \x27
 COMMON_ESCAPE = ( [nrt0\n\r\\] | "x" {HEX_DIGIT} {2} | "u" {HEX_DIGIT} {4} | "U" {HEX_DIGIT} {8} )
 SCHAR = {SINGLE_QUOTE} (( [^'\\] | "\\" ( {SINGLE_QUOTE} | {COMMON_ESCAPE}) ) | [^\x20-\x7E]{1,2}) {SINGLE_QUOTE}
-STRING = {DOUBLE_QUOTE} ( [^\"\\] | "\\" ( {DOUBLE_QUOTE} | {SINGLE_QUOTE} | {COMMON_ESCAPE}) )* {DOUBLE_QUOTE}
+STRING = {DOUBLE_QUOTE} ( [^\"\\] | "\\" ( {DOUBLE_QUOTE} | {SINGLE_QUOTE} | {COMMON_ESCAPE} | [dwWstrn.]) )* {DOUBLE_QUOTE} // dwWstrn - modifiers for slashed params, e.g \d
 
 %%
 <YYINITIAL> {


### PR DESCRIPTION
* Fixed regex recognition
* Fixed variable definition like 
  ```zep
  {someVar} = someValue;
  ```

[zephir-0.3.2-beta3.zip](https://github.com/phalcon/zephir-idea-plugin/files/1157422/Zephir.3.2.beta3.zip)
